### PR TITLE
[add] image node

### DIFF
--- a/dashboard/nodes/soop_image.html
+++ b/dashboard/nodes/soop_image.html
@@ -1,0 +1,187 @@
+<script src="socket.io/socket.io.js"></script>
+<script type="text/javascript">
+
+    // Temporally save recent file in base64 format
+    var strImage;
+
+    // When user uploads image, change image file into base64 string and save it.
+    function uploadFile(info){
+        const reader = new FileReader();
+        reader.onload = function() {
+            const base64 = this.result.replace(/.*base64,/, '');
+            
+            strImage = base64;
+        };
+        reader.readAsDataURL(info.files[0]);
+    }
+
+    // Register Image Node
+    RED.nodes.registerType('soop_image', {
+        /* Node definitions
+        *  category: palette category
+        *  color: background color
+        *  defaults: node property
+        *  inputs: # of input
+        *  outputs: # of output
+        *  icon: icon image
+        *  paletteLabel: node name in palette
+        *  label: function that returns value for the label name
+        *  labelstyle: function that returns css-style for the label
+        *  oneditprepare: function called when edit window is opened
+        *  oneditsave: function called when edit window is okayed
+        */
+        category: "soop-dashboard",
+        color: 'rgb(100, 189, 27)',
+        defaults: {
+            /* Node Properties (value, required, validate, type)
+            *  name: node name on palette
+            *  tooltip: tooltip of the image
+            *  group: group information of the node
+            *  order: order of the node
+            *  width, height: size of node
+            *  source: image upload option 
+            *  uploads: base64 string of uploaded local image file
+            *  link: URL of the image file
+            *  fits: cut option of the image
+            */
+            name: { value: '' },
+            tooltip: { value: '' },
+            group: {
+                type: 'ui_group',
+                required: true
+            },
+            width: {
+                value: 0,
+                validate: function(v) {
+                    var width = v || 0;
+                    var currentGroup = $('#node-input-group').val() || this.group;
+                    var groupNode = RED.nodes.node(currentGroup);
+                    var valid = !groupNode || +width <= +groupNode.width;
+                    $("#node-input-size").toggleClass("input-error", !valid);
+                    return valid;
+                }
+            },
+            height: {
+                value: 0
+            },
+            source: { value: 'upload' },
+            uploads: { value: "" },
+            link: { value: "" },
+            fits: { value: 'fill' },
+        },
+        inputs: 0,
+        outputs: 0,
+        icon: "font-awesome/fa-picture-o",
+        paletteLabel: 'soop_image',
+        label: function() {
+            return this.name || 'soop_image';
+        },
+
+        oneditprepare: function() {
+            $("#node-input-size").elementSizer({
+                width: "#node-input-width",
+                height: "#node-input-height",
+                group: "#node-input-group"
+            });
+
+            // On change event, change dom element
+            $('#node-input-source').on("change", function() {
+                if ($('#node-input-source').val() === "upload") {
+                    $('#node-input-link').val('');
+                    $(".form-row-link").hide();
+                    $(".form-row-upload").show();
+                }
+                else if ($('#node-input-source').val() === "link") {
+                    $('#node-input-upload').val('');
+                    $(".form-row-upload").hide();
+                    $(".form-row-link").show();
+                }
+            });
+            
+            // According to input, call event function
+            $('#node-input-source').change();
+
+            // Set default fit option
+            if (!$("#node-input-fits").val()) { $("#node-input-fits").val("fill") }
+            
+        },
+        oneditsave: function () {
+            if($('#node-input-source').val() === "upload"){
+                this.uploads = strImage;
+                console.log("T",this.uploads);
+            }else{
+                this.uploads = "";
+                console.log("F",this.uploads);
+            }
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="soop_image">
+    <!-- Group -->
+    <div class="form-row">
+        <label for="node-input-group"><i class="fa fa-table"></i> Group</label>
+        <input type="text" id="node-input-group">
+    </div>
+    <!-- Size -->
+    <div class="form-row">
+        <label><i class="fa fa-object-group"></i> Size</label>
+        <input type="hidden" id="node-input-width">
+        <input type="hidden" id="node-input-height">
+        <button class="editor-button" id="node-input-size"></button>
+    </div>
+    <!-- Source -->
+    <div class="form-row">
+        <label for="node-input-source"><i class="fa fa-file-image-o"></i> Source</label>
+        <select id="node-input-source" style="width:204px">
+            <option value="upload">Upload Image</option>
+            <option value="link">File URL</option>
+        </select>
+    </div>
+    <!-- Source-Upload -->
+    <div class="form-row form-row-upload">
+        <label for="node-input-upload" style="text-align:right;"><i class="fa fa-upload"></i> File</label>
+        <input type="file" id="node-input-upload" accept="image/*" onchange="uploadFile(this)" style="width:204px">
+    </div>
+    <!-- Source-URL -->
+    <div class="form-row form-row-link">
+        <label for="node-input-link" style="text-align:right;"><i class="fa fa-link"></i> URL</label>
+        <input type="text" id="node-input-link" style="width:204px">
+    </div>
+
+    <!-- Object fit -->
+    <div class="form-row">
+        <label for="node-input-fits"><i class="fa fa-crop"></i> Object fit</label>
+        <select id="node-input-fits" style="width:204px">
+            <option value="fill">fill</option>
+            <option value="contain">contain</option>
+            <option value="cover">cover</option>
+        </select>
+    </div>
+    <!-- Name -->
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name">
+    </div>
+
+</script>
+
+<script type="text/html" data-help-name="soop_image">
+    <p>Helper Text is not ready</p>
+    <p>It'll be revised</p>
+    <!--
+    <p>Adds a slider widget to the user interface.</p>
+    <p>The user can change its value between the limits (<b>min</b> and <b>max</b>). Each value change
+    will generate a message with the value set as <b>payload</b>.</p>
+    <p>A vertical slider can be created by setting the size so that the height is greater than the width.</p>
+    <p>The slider can be reversed by setting the min value larger than the max value. e.g. min 100, max 0.</p>
+    <p>If a <b>Topic</b> is specified, it will be added as <code>msg.topic</code>.</p>
+    <p>An input <code>msg.payload</code> will be converted to a number, and used to preset a value.
+    The <b>min</b> value will be used if conversion fails,
+    and it will update the user interface. If the value changes, it will also be passed to the output.</p>
+    <p>The label can also be set by a message property by setting
+    the field to the name of the property, for example <code>{{msg.topic}}</code>.</p>
+    <p>Setting <code>msg.enabled</code> to <code>false</code> will disable the slider output.</p>
+    <p>If a <b>Class</b> is specified, it will be added to the parent card. This way you can style the card and the elements inside it with custom CSS. The Class can be set at runtime by setting a <code>msg.className</code> string property.</p>
+    -->
+</script>

--- a/dashboard/nodes/soop_image.js
+++ b/dashboard/nodes/soop_image.js
@@ -1,0 +1,26 @@
+module.exports = function(RED) {
+    // var ui = require('../ui')(RED);
+    const dashboard = require("../dashboard")(RED);
+
+    function SoopImageNode(config) {
+        // Node Constructor
+        RED.nodes.createNode(this, config);
+
+        var node = this;
+
+        // var group = RED.nodes.getNode(config.group);
+        // if (!group) { return; }
+        // var tab = RED.nodes.getNode(group.config.tab);
+        // if (!tab) { return; }
+
+        // Send Runtime information to react
+        dashboard.addNode({
+            node: node,
+            onMessage: (message) => {
+              console.log(message);
+              node.send("received message from a dashboard");
+            },
+        });
+    }
+    RED.nodes.registerType("soop_image", SoopImageNode);
+};


### PR DESCRIPTION
- image node proto type 완성
  - upload 옵션: image를 base64로 변환한 string을 runtime에 저장
  - link 옵션: image의 URL string을 runtime에 저장
- runtime --> react 통신
  - socket을 통해 전달받은 base64 string을 img 태그로 변환해서 사용
  ex)
```
socket.on('FRONT_SOCKET_TYPE.INIT_NODE', states => {
    // 이미지 태그 생성
    const img = new Image();
    // 이미지 태그의 타입과 source 설정, 
    img.src = \`data:image/jpg;base64,${states.uploads}`;
    // img 태그 삽입
    document.getElementsById('DOM Element 이름').appendChild(img);
});
```